### PR TITLE
Allow URL encoded names and use the action URL

### DIFF
--- a/src/Elements/Action.php
+++ b/src/Elements/Action.php
@@ -113,7 +113,10 @@ class Action extends Base
      */
     private function mapUriTemplate()
     {
-        return $this->modifyUriTemplate($this->parent->reynaldo->getHref(), $this->parameters, false);
+        $attributeUri = $this->reynaldo->getAttribute('href');
+        $uri = $attributeUri !== null ? $attributeUri : $this->parent->reynaldo->getHref();
+
+        return $this->modifyUriTemplate($uri, $this->parameters, false);
     }
 
     /**
@@ -123,7 +126,10 @@ class Action extends Base
      */
     private function mapColorizedUriTemplate()
     {
-        return $this->modifyUriTemplate($this->parent->reynaldo->getHref(), $this->parameters, true);
+        $attributeUri = $this->reynaldo->getAttribute('href');
+        $uri = $attributeUri !== null ? $attributeUri : $this->parent->reynaldo->getHref();
+
+        return $this->modifyUriTemplate($uri, $this->parameters, true);
     }
 
     /**

--- a/src/Elements/HrefVariable.php
+++ b/src/Elements/HrefVariable.php
@@ -63,7 +63,7 @@ class HrefVariable extends Mapping
      */
     public function setup()
     {
-        $this->name = $this->reynaldo->name;
+        $this->name = urldecode($this->reynaldo->name);
         $this->description = $this->reynaldo->description;
         $this->descriptionHtml = resolve('Parsedown')->parse($this->reynaldo->description);
         $this->type = $this->reynaldo->dataType;


### PR DESCRIPTION
This PR will solve the following two cases:

## URL Encoded names
If the name of a call is, for example, `### Get books filtered on genre [GET /books{?filter%5Bgenre%5D}]`, the `{?filter[genre]}` part is not shown in the URL, because of the `urldecode` on [this line](https://github.com/M165437/laravel-blueprint-docs/blob/master/src/Elements/Action.php#L158). By setting the name using `urldecode`, `{?filter[genre]}` is used everywhere instead of encode characters.

## Use action URL
According to JSON API standard it is possible to access a resource relation using an URL like `/books/{id}/author`. However, the `mapUriTemplate` method always uses the href of the parent, resulting in two documenation 'blocks', consisting both of `/books/{id}` instead of one `books/{id}` and `books/{id}/author`.

---

Both changes were required for our API documentation to work, which are a lot more advanced than the available examples. Our documentation follows the JSON API standard, so I think there are more users that will ecounter this problems as soon as stuff gets a bit more advanced.