### PR TITLE
Get type from Parameter Object instead

### DIFF
--- a/resources/views/parameters.blade.php
+++ b/resources/views/parameters.blade.php
@@ -5,8 +5,8 @@
     <table>
         <thead>
         <tr>
-            <th></th>
-            <th></th>
+            <th>Parameter</th>
+            <th>Description</th>
         </tr>
         </thead>
         <tbody>

--- a/resources/views/parameters.blade.php
+++ b/resources/views/parameters.blade.php
@@ -17,7 +17,7 @@
                 </td>
                 <td>
                     <p>
-                        <code>string</code>
+                        <code>{{$parameter->type}}</code>
                         @if ($parameter->required)
                             &nbsp;({{ $parameter->required }})
                         @endif


### PR DESCRIPTION
Get actual type from the parameter object. This way if it is number it works.