### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "laravel/framework": ">=5.4|~7.0",
         "hmaus/drafter-php": "^5.0",
         "hmaus/reynaldo": "^0.1.3",
         "erusev/parsedown": "^1.7.0",


### PR DESCRIPTION
- Bump supported version of Laravel to `~7.0`